### PR TITLE
Support for Field Kit controls in XIBs

### DIFF
--- a/lib/FKScrollField/FKScrollField.m
+++ b/lib/FKScrollField/FKScrollField.m
@@ -43,22 +43,14 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        // Set up self
-        self.clipsToBounds = NO;
-        
-        // Set up subviews
-        _textView = nil;
-        _textField = [[UITextField alloc] init];
-        _textField.frame = CGRectMake(0, 0, frame.size.width, frame.size.height);
-        //_textField.clipsToBounds = NO;
-        [_textField addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
-        _textField.delegate = self;
-        [self addSubview:_textField];    
-        
-        // Add self key-value observing
-        [self addObserver:self forKeyPath:@"editing" options:(NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld) context:nil];
+        [ self setupInstance ] ;
     }
     return self;
+}
+
+- (void)awakeFromNib
+{
+    [ self setupInstance ] ;
 }
 
 - (void)dealloc
@@ -75,6 +67,24 @@
 #if !__has_feature(objc_arc)
     [super dealloc];
 #endif
+}
+
+- (void)setupInstance
+{
+    // Set up self
+    self.clipsToBounds = NO;
+    
+    // Set up subviews
+    _textView = nil;
+    _textField = [[UITextField alloc] init];
+    _textField.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
+    //_textField.clipsToBounds = NO;
+    [_textField addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
+    _textField.delegate = self;
+    [self addSubview:_textField];
+    
+    // Add self key-value observing
+    [self addObserver:self forKeyPath:@"editing" options:(NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld) context:nil];
 }
 
 #pragma mark -

--- a/lib/FKScrollField/FKScrollField.m
+++ b/lib/FKScrollField/FKScrollField.m
@@ -50,6 +50,7 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self setupInstance];
 }
 

--- a/lib/FKScrollField/FKScrollField.m
+++ b/lib/FKScrollField/FKScrollField.m
@@ -43,7 +43,7 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        [self setupInstance];
+        [self setupScrollFieldInstance];
     }
     return self;
 }
@@ -51,7 +51,7 @@
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-    [self setupInstance];
+    [self setupScrollFieldInstance];
 }
 
 - (void)dealloc
@@ -70,7 +70,7 @@
 #endif
 }
 
-- (void)setupInstance
+- (void)setupScrollFieldInstance
 {
     // Set up self
     self.clipsToBounds = NO;

--- a/lib/FKScrollField/FKScrollField.m
+++ b/lib/FKScrollField/FKScrollField.m
@@ -43,14 +43,14 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        [ self setupInstance ] ;
+        [self setupInstance];
     }
     return self;
 }
 
 - (void)awakeFromNib
 {
-    [ self setupInstance ] ;
+    [self setupInstance];
 }
 
 - (void)dealloc

--- a/lib/FKTextField/FKTextField.m
+++ b/lib/FKTextField/FKTextField.m
@@ -51,7 +51,7 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        [self setupInstance];
+        [self setupTextFieldInstance];
     }
     return self;
 }
@@ -76,10 +76,10 @@
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-    [self setupInstance];
+    [self setupTextFieldInstance];
 }
 
-- (void)setupInstance
+- (void)setupTextFieldInstance
 {
     // Set up view
     self.backgroundColor = [FKTextAppearance defaultBackgroundColor];

--- a/lib/FKTextField/FKTextField.m
+++ b/lib/FKTextField/FKTextField.m
@@ -51,23 +51,7 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        // Set up view
-        self.backgroundColor = [FKTextAppearance defaultBackgroundColor];
-        _editing = NO;
-        _editable = YES; // default
-        
-        // Set up content view
-        _contentView = [[FKTextContentView alloc] initWithFrame:self.bounds];
-        _contentView.autoresizingMask = (UIViewAutoresizingFlexibleRightMargin|UIViewAutoresizingFlexibleBottomMargin); // autoresizing handled in layoutSubviews
-        _contentView.contentMode = UIViewContentModeBottomLeft; // don't scale text content view
-        [self addSubview:_contentView];
-        
-        // Set up selection view
-        _selectionView = [[FKTextSelectionView alloc] initWithSelectingContainer:self];
-        _selectionView.autoresizingMask = (UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight);
-        
-        // Set up interaction assistant
-        _interactionAssistant = [[FKTextInteractionAssistant alloc] initWithSelectingContainer:self];
+        [ self setupInstance ] ;
     }
     return self;
 }
@@ -89,10 +73,36 @@
     
 }
 
+- (void)awakeFromNib
+{
+    [ self setupInstance ] ;
+}
+
+- (void)setupInstance
+{
+    // Set up view
+    self.backgroundColor = [FKTextAppearance defaultBackgroundColor];
+    _editing = NO;
+    _editable = YES; // default
+    
+    // Set up content view
+    _contentView = [[FKTextContentView alloc] initWithFrame:self.bounds];
+    _contentView.autoresizingMask = (UIViewAutoresizingFlexibleRightMargin|UIViewAutoresizingFlexibleBottomMargin); // autoresizing handled in layoutSubviews
+    _contentView.contentMode = UIViewContentModeBottomLeft; // don't scale text content view
+    [self addSubview:_contentView];
+    
+    // Set up selection view
+    _selectionView = [[FKTextSelectionView alloc] initWithSelectingContainer:self];
+    _selectionView.autoresizingMask = (UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight);
+    
+    // Set up interaction assistant
+    _interactionAssistant = [[FKTextInteractionAssistant alloc] initWithSelectingContainer:self];
+}
+
 #pragma mark -
 #pragma mark Properties
 
-- (NSString *)text 
+- (NSString *)text
 {
     return _contentView.text;
 }

--- a/lib/FKTextField/FKTextField.m
+++ b/lib/FKTextField/FKTextField.m
@@ -51,7 +51,7 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        [ self setupInstance ] ;
+        [self setupInstance];
     }
     return self;
 }
@@ -75,7 +75,7 @@
 
 - (void)awakeFromNib
 {
-    [ self setupInstance ] ;
+    [self setupInstance];
 }
 
 - (void)setupInstance

--- a/lib/FKTextField/FKTextField.m
+++ b/lib/FKTextField/FKTextField.m
@@ -75,6 +75,7 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self setupInstance];
 }
 

--- a/lib/FKTextField/FKTextField_Internal.h
+++ b/lib/FKTextField/FKTextField_Internal.h
@@ -57,7 +57,6 @@
 
 @property(nonatomic, readwrite) BOOL editing;
 
-- (void)setupInstance;
 - (void)showSelectionView:(BOOL)visible;
 
 @end

--- a/lib/FKTextField/FKTextField_Internal.h
+++ b/lib/FKTextField/FKTextField_Internal.h
@@ -57,6 +57,7 @@
 
 @property(nonatomic, readwrite) BOOL editing;
 
+- (void)setupInstance;
 - (void)showSelectionView:(BOOL)visible;
 
 @end

--- a/lib/FKTokenField/FKTokenField.m
+++ b/lib/FKTokenField/FKTokenField.m
@@ -28,7 +28,6 @@
 #import "FKTokenField.h"
 #import "FKTokenField_Internal.h"
 #import "FKTextField+UITextInput.h"
-#import "FKTextField_Internal.h"
 
 @implementation FKTokenField
 
@@ -94,13 +93,12 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self setupInstance];
 }
 
 - (void)setupInstance
 {
-    [super setupInstance];
-    
     // Set up view
     self.backgroundColor = [UIColor whiteColor];
     

--- a/lib/FKTokenField/FKTokenField.m
+++ b/lib/FKTokenField/FKTokenField.m
@@ -63,9 +63,9 @@
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
-    if (self) 
+    if (self)
     {
-        [self setupInstance];
+        [self setupTokenFieldInstance];
     }
     return self;
 }
@@ -94,10 +94,10 @@
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-    [self setupInstance];
+    [self setupTokenFieldInstance];
 }
 
-- (void)setupInstance
+- (void)setupTokenFieldInstance
 {
     // Set up view
     self.backgroundColor = [UIColor whiteColor];

--- a/lib/FKTokenField/FKTokenField.m
+++ b/lib/FKTokenField/FKTokenField.m
@@ -28,6 +28,7 @@
 #import "FKTokenField.h"
 #import "FKTokenField_Internal.h"
 #import "FKTextField+UITextInput.h"
+#import "FKTextField_Internal.h"
 
 @implementation FKTokenField
 
@@ -65,7 +66,7 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        [ self setupInstance ] ;
+        [self setupInstance];
     }
     return self;
 }
@@ -93,12 +94,12 @@
 
 - (void)awakeFromNib
 {
-    [ self setupInstance ] ;
+    [self setupInstance];
 }
 
 - (void)setupInstance
 {
-    [ super setupInstance ] ;
+    [super setupInstance];
     
     // Set up view
     self.backgroundColor = [UIColor whiteColor];

--- a/lib/FKTokenField/FKTokenField.m
+++ b/lib/FKTokenField/FKTokenField.m
@@ -65,43 +65,7 @@
     self = [super initWithFrame:frame];
     if (self) 
     {
-        // Set up view
-        self.backgroundColor = [UIColor whiteColor];
-        
-        // Set up default geometry properties
-        _inset = kFKTokenFieldDefaultInset;
-        _padding = kFKTokenFieldDefaultPadding;
-        
-        // Set up default tokenizing character set
-        self.tokenizingCharacterSet = kFKTokenFieldDefaultTokenizers;
-        
-        // Set up token fields
-        self.tokenFieldCells = [NSMutableArray array];
-        _selectedTokenFieldCell = nil;
-        
-        // Set up completion view
-        self.completionTimer = nil;
-        self.completionDelay = kFKTokenFieldDefaultCompletionDelay;
-        self.completionSuperview = nil;
-        UITableView * completionListView = [[UITableView alloc] initWithFrame:self.bounds style:UITableViewStylePlain];
-        completionListView.autoresizingMask = (UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleBottomMargin);
-        completionListView.delegate = self;
-        completionListView.dataSource = self;
-        self.completionListView = completionListView;
-#if !__has_feature(objc_arc)
-        [completionListView release];
-#endif
-        
-        // Set up long press gesture recognizer
-        _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGesture:)];
-        _longPressGestureRecognizer.delegate = self;
-        [self addGestureRecognizer:_longPressGestureRecognizer];
-#if !__has_feature(objc_arc)
-        [_longPressGestureRecognizer release];
-#endif
-        
-        // Register for keyboard notifications (needed to get keyboard's frame)
-        [self registerForKeyboardNotifications];
+        [ self setupInstance ] ;
     }
     return self;
 }
@@ -125,6 +89,54 @@
     
     [super dealloc];
 #endif
+}
+
+- (void)awakeFromNib
+{
+    [ self setupInstance ] ;
+}
+
+- (void)setupInstance
+{
+    [ super setupInstance ] ;
+    
+    // Set up view
+    self.backgroundColor = [UIColor whiteColor];
+    
+    // Set up default geometry properties
+    _inset = kFKTokenFieldDefaultInset;
+    _padding = kFKTokenFieldDefaultPadding;
+    
+    // Set up default tokenizing character set
+    self.tokenizingCharacterSet = kFKTokenFieldDefaultTokenizers;
+    
+    // Set up token fields
+    self.tokenFieldCells = [NSMutableArray array];
+    _selectedTokenFieldCell = nil;
+    
+    // Set up completion view
+    self.completionTimer = nil;
+    self.completionDelay = kFKTokenFieldDefaultCompletionDelay;
+    self.completionSuperview = nil;
+    UITableView * completionListView = [[UITableView alloc] initWithFrame:self.bounds style:UITableViewStylePlain];
+    completionListView.autoresizingMask = (UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleBottomMargin);
+    completionListView.delegate = self;
+    completionListView.dataSource = self;
+    self.completionListView = completionListView;
+#if !__has_feature(objc_arc)
+    [completionListView release];
+#endif
+    
+    // Set up long press gesture recognizer
+    _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGesture:)];
+    _longPressGestureRecognizer.delegate = self;
+    [self addGestureRecognizer:_longPressGestureRecognizer];
+#if !__has_feature(objc_arc)
+    [_longPressGestureRecognizer release];
+#endif
+    
+    // Register for keyboard notifications (needed to get keyboard's frame)
+    [self registerForKeyboardNotifications];
 }
 
 #pragma mark -


### PR DESCRIPTION
This pull request adds an awakeFromNib method to each of the 3 widgets so that they can be created via Interface Builder with the correct type and still have them function when the NIB loads.  All of the initialization code that was in the init... method has been moved into a setupInstance method that is invoked both in the init method as well as in the awakeFromNib method.