### PR TITLE
Text field delegate methods

### DIFF
--- a/lib/FKTextField/FKTextField.m
+++ b/lib/FKTextField/FKTextField.m
@@ -169,64 +169,55 @@
 
 - (BOOL)canBecomeFirstResponder
 {
-    BOOL becoming = YES ;
-    
-    return becoming;
-}
-
-- (BOOL)canResignFirstResponder
-{
-    BOOL resigning = YES ;
-    
-    return resigning ;
+    return YES;
 }
 
 - (BOOL)resignFirstResponder
 {
-    BOOL resigning = YES ;
+    BOOL willResign = YES ;
     
-    resigning = [ super resignFirstResponder ] ;
+    willResign = [super resignFirstResponder] ;
     
-    if ( self.editing && resigning && _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldEndEditing:)])
+    if ( self.editing && willResign && _delegate && [_delegate respondsToSelector:@selector(textFieldShouldEndEditing:)])
     {
-        resigning = [ _delegate textFieldShouldEndEditing:self ] ;
+        willResign = [_delegate textFieldShouldEndEditing:self] ;
     }
     
-    if ( self.editing && resigning )
+    if ( self.editing && willResign )
     {
         self.editing = NO;
         
-        if ( _delegate && ( [_delegate respondsToSelector:@selector(textFieldDidEndEditing:) ]))
+        if ( _delegate && ( [_delegate respondsToSelector:@selector(textFieldDidEndEditing:)]))
         {
-            [_delegate textFieldDidEndEditing:self ] ;
+            [_delegate textFieldDidEndEditing:self] ;
         }
     }
     
-	return resigning ;
+	return willResign ;
 }
 
 - (BOOL)becomeFirstResponder
 {
-    BOOL becoming = YES ;
+    BOOL willBecome = YES ;
     
-    becoming = [ super becomeFirstResponder ] ;
+    willBecome = [super becomeFirstResponder] ;
     
-    if ( !self.editing && becoming && _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldBeginEditing:)])
+    if ( !self.editing && willBecome && _delegate && [_delegate respondsToSelector:@selector(textFieldShouldBeginEditing:)])
     {
-        becoming = [ _delegate textFieldShouldBeginEditing:self ] ;
+        willBecome = [_delegate textFieldShouldBeginEditing:self] ;
     }
     
-    if ( !self.editing && becoming )
+    if ( !self.editing && willBecome )
     {
         self.editing = YES;
         
         if ( _delegate && [_delegate respondsToSelector:@selector(textFieldDidBeginEditing:)])
         {
-            [ _delegate textFieldDidBeginEditing:self ] ;
+            [_delegate textFieldDidBeginEditing:self] ;
         }
     }
     
-    return becoming;
+    return willBecome;
 }
 
 - (UIView *)inputAccessoryView

--- a/lib/FKTextField/FKTextField.m
+++ b/lib/FKTextField/FKTextField.m
@@ -171,22 +171,12 @@
 {
     BOOL becoming = YES ;
     
-    if ( _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldBeginEditing:)])
-    {
-        becoming = [ _delegate textFieldShouldBeginEditing:self ] ;
-    }
-    
     return becoming;
 }
 
 - (BOOL)canResignFirstResponder
 {
     BOOL resigning = YES ;
-    
-    if ( _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldEndEditing:)])
-    {
-        resigning = [ _delegate textFieldShouldEndEditing:self ] ;
-    }
     
     return resigning ;
 }
@@ -197,7 +187,12 @@
     
     resigning = [ super resignFirstResponder ] ;
     
-    if ( resigning )
+    if ( self.editing && resigning && _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldEndEditing:)])
+    {
+        resigning = [ _delegate textFieldShouldEndEditing:self ] ;
+    }
+    
+    if ( self.editing && resigning )
     {
         self.editing = NO;
         
@@ -216,7 +211,12 @@
     
     becoming = [ super becomeFirstResponder ] ;
     
-    if ( becoming )
+    if ( !self.editing && becoming && _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldBeginEditing:)])
+    {
+        becoming = [ _delegate textFieldShouldBeginEditing:self ] ;
+    }
+    
+    if ( !self.editing && becoming )
     {
         self.editing = YES;
         

--- a/lib/FKTextField/FKTextField.m
+++ b/lib/FKTextField/FKTextField.m
@@ -169,22 +169,64 @@
 
 - (BOOL)canBecomeFirstResponder
 {
-    return YES;
+    BOOL becoming = YES ;
+    
+    if ( _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldBeginEditing:)])
+    {
+        becoming = [ _delegate textFieldShouldBeginEditing:self ] ;
+    }
+    
+    return becoming;
+}
+
+- (BOOL)canResignFirstResponder
+{
+    BOOL resigning = YES ;
+    
+    if ( _delegate && [ _delegate respondsToSelector:@selector(textFieldShouldEndEditing:)])
+    {
+        resigning = [ _delegate textFieldShouldEndEditing:self ] ;
+    }
+    
+    return resigning ;
 }
 
 - (BOOL)resignFirstResponder
 {
-    self.editing = NO;
+    BOOL resigning = YES ;
     
-	return [super resignFirstResponder];
+    resigning = [ super resignFirstResponder ] ;
+    
+    if ( resigning )
+    {
+        self.editing = NO;
         
+        if ( _delegate && ( [_delegate respondsToSelector:@selector(textFieldDidEndEditing:) ]))
+        {
+            [_delegate textFieldDidEndEditing:self ] ;
+        }
+    }
+    
+	return resigning ;
 }
 
 - (BOOL)becomeFirstResponder
 {
-    self.editing = YES;
+    BOOL becoming = YES ;
     
-    return [super becomeFirstResponder];
+    becoming = [ super becomeFirstResponder ] ;
+    
+    if ( becoming )
+    {
+        self.editing = YES;
+        
+        if ( _delegate && [_delegate respondsToSelector:@selector(textFieldDidBeginEditing:)])
+        {
+            [ _delegate textFieldDidBeginEditing:self ] ;
+        }
+    }
+    
+    return becoming;
 }
 
 - (UIView *)inputAccessoryView

--- a/lib/FKTokenField/FKTokenField.m
+++ b/lib/FKTokenField/FKTokenField.m
@@ -269,6 +269,7 @@
         CGRect contentViewFrame = _contentView.frame;
         contentViewFrame.origin.x = offset.x;
         contentViewFrame.origin.y = offset.y + 2; // check with cell for insets...
+        contentViewFrame.size.height = offset.y + offsetTolerance ;
      
         // Update content view
         _contentView.frame = contentViewFrame;

--- a/lib/FKTokenField/FKTokenField.m
+++ b/lib/FKTokenField/FKTokenField.m
@@ -269,7 +269,6 @@
         CGRect contentViewFrame = _contentView.frame;
         contentViewFrame.origin.x = offset.x;
         contentViewFrame.origin.y = offset.y + 2; // check with cell for insets...
-        contentViewFrame.size.height = offset.y + offsetTolerance ;
      
         // Update content view
         _contentView.frame = contentViewFrame;


### PR DESCRIPTION
Added in logic to invoke the FKTextFieldDelegate methods for:

```
textFieldShouldBeginEditing:
textFieldDidBeginEditing:
textFieldShouldEndEditing: 
textFieldDidEndEditing: 
```

The remaining Delegate methods are not yet implemented.
